### PR TITLE
Quantization Config support

### DIFF
--- a/builtin-adapter/BuiltinAdapter.cpp
+++ b/builtin-adapter/BuiltinAdapter.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Restream
+ * Copyright 2020-present Restream
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/builtin-adapter/BuiltinAdapter.h
+++ b/builtin-adapter/BuiltinAdapter.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Restream
+ * Copyright 2020-present Restream
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/header.txt
+++ b/header.txt
@@ -1,4 +1,4 @@
-Copyright 2020 Restream
+Copyright 2020-present Restream
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/main/java/ru/rt/restream/reindexer/AggregationResult.java
+++ b/src/main/java/ru/rt/restream/reindexer/AggregationResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Restream
+ * Copyright 2020-present Restream
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/ru/rt/restream/reindexer/CollateMode.java
+++ b/src/main/java/ru/rt/restream/reindexer/CollateMode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Restream
+ * Copyright 2020-present Restream
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/ru/rt/restream/reindexer/EnumType.java
+++ b/src/main/java/ru/rt/restream/reindexer/EnumType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Restream
+ * Copyright 2020-present Restream
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/ru/rt/restream/reindexer/FieldType.java
+++ b/src/main/java/ru/rt/restream/reindexer/FieldType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Restream
+ * Copyright 2020-present Restream
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/ru/rt/restream/reindexer/IndexType.java
+++ b/src/main/java/ru/rt/restream/reindexer/IndexType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Restream
+ * Copyright 2020-present Restream
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/ru/rt/restream/reindexer/Namespace.java
+++ b/src/main/java/ru/rt/restream/reindexer/Namespace.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Restream
+ * Copyright 2020-present Restream
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/ru/rt/restream/reindexer/NamespaceOptions.java
+++ b/src/main/java/ru/rt/restream/reindexer/NamespaceOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Restream
+ * Copyright 2020-present Restream
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/ru/rt/restream/reindexer/Query.java
+++ b/src/main/java/ru/rt/restream/reindexer/Query.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Restream
+ * Copyright 2020-present Restream
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/ru/rt/restream/reindexer/QueryLogBuilder.java
+++ b/src/main/java/ru/rt/restream/reindexer/QueryLogBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Restream
+ * Copyright 2020-present Restream
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/ru/rt/restream/reindexer/QueryResultIterator.java
+++ b/src/main/java/ru/rt/restream/reindexer/QueryResultIterator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Restream
+ * Copyright 2020-present Restream
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/ru/rt/restream/reindexer/QueryResultJsonIterator.java
+++ b/src/main/java/ru/rt/restream/reindexer/QueryResultJsonIterator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Restream
+ * Copyright 2020-present Restream
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/ru/rt/restream/reindexer/ReindexScanner.java
+++ b/src/main/java/ru/rt/restream/reindexer/ReindexScanner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Restream
+ * Copyright 2020-present Restream
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/ru/rt/restream/reindexer/Reindexer.java
+++ b/src/main/java/ru/rt/restream/reindexer/Reindexer.java
@@ -282,28 +282,16 @@ public class Reindexer implements AutoCloseable {
         return new Query<>(this, namespace, null);
     }
 
-    /**
-     * ONLY FOR TEST PURPOSES!
-     */
-    @Deprecated
     public void addIndex(String namespaceName, ReindexerIndex index) {
         IndexDefinition indexDefinition = IndexDefinition.fromIndex(index);
         binding.addIndex(namespaceName, indexDefinition);
     }
 
-    /**
-     * ONLY FOR TEST PURPOSES!
-     */
-    @Deprecated
     public void updateIndex(String namespaceName, ReindexerIndex index) {
         IndexDefinition indexDefinition = IndexDefinition.fromIndex(index);
         binding.updateIndex(namespaceName, indexDefinition);
     }
 
-    /**
-     * ONLY FOR TEST PURPOSES!
-     */
-    @Deprecated
     public void dropIndex(String namespaceName, String indexName) {
         binding.dropIndex(namespaceName, indexName);
     }

--- a/src/main/java/ru/rt/restream/reindexer/Reindexer.java
+++ b/src/main/java/ru/rt/restream/reindexer/Reindexer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Restream
+ * Copyright 2020-present Restream
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/ru/rt/restream/reindexer/ReindexerConfiguration.java
+++ b/src/main/java/ru/rt/restream/reindexer/ReindexerConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Restream
+ * Copyright 2020-present Restream
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/ru/rt/restream/reindexer/ReindexerIndex.java
+++ b/src/main/java/ru/rt/restream/reindexer/ReindexerIndex.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Restream
+ * Copyright 2020-present Restream
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/ru/rt/restream/reindexer/ReindexerNamespace.java
+++ b/src/main/java/ru/rt/restream/reindexer/ReindexerNamespace.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Restream
+ * Copyright 2020-present Restream
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/ru/rt/restream/reindexer/ReindexerResponse.java
+++ b/src/main/java/ru/rt/restream/reindexer/ReindexerResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Restream
+ * Copyright 2020-present Restream
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/ru/rt/restream/reindexer/ResultIterator.java
+++ b/src/main/java/ru/rt/restream/reindexer/ResultIterator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Restream
+ * Copyright 2020-present Restream
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/ru/rt/restream/reindexer/TimeUnit.java
+++ b/src/main/java/ru/rt/restream/reindexer/TimeUnit.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Restream
+ * Copyright 2020-present Restream
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/ru/rt/restream/reindexer/Transaction.java
+++ b/src/main/java/ru/rt/restream/reindexer/Transaction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Restream
+ * Copyright 2020-present Restream
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/ru/rt/restream/reindexer/annotations/Convert.java
+++ b/src/main/java/ru/rt/restream/reindexer/annotations/Convert.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Restream
+ * Copyright 2020-present Restream
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/ru/rt/restream/reindexer/annotations/Enumerated.java
+++ b/src/main/java/ru/rt/restream/reindexer/annotations/Enumerated.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Restream
+ * Copyright 2020-present Restream
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/ru/rt/restream/reindexer/annotations/FullText.java
+++ b/src/main/java/ru/rt/restream/reindexer/annotations/FullText.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Restream
+ * Copyright 2020-present Restream
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/ru/rt/restream/reindexer/annotations/Hnsw.java
+++ b/src/main/java/ru/rt/restream/reindexer/annotations/Hnsw.java
@@ -79,4 +79,40 @@ public @interface Hnsw {
      */
     boolean multithreading() default false;
 
+    /**
+     * Optional quantization configuration for HNSW index.
+     *
+     * <p>When {@code quantizationConfig.quantizationType} is empty, the whole block is ignored.
+     *
+     * <p>Currently supported type: {@code scalar_quantization_8_bit}.
+     */
+    QuantizationConfig quantizationConfig() default @QuantizationConfig;
+
+    /**
+     * Nested annotation representing {@code quantization_config} block.
+     */
+    @interface QuantizationConfig {
+        /**
+         * Quantization type.
+         *
+         * <p>Currently supported: {@code scalar_quantization_8_bit}.
+         */
+        String quantizationType() default "";
+
+        /**
+         * Quantile for scalar quantization.
+         */
+        float quantile() default -1.0f;
+
+        /**
+         * Sample size for estimating quantile(s).
+         */
+        int sampleSize() default 20_000;
+
+        /**
+         * Minimal number of points in the index required to enable quantization.
+         */
+        int quantizationThreshold() default 100_000;
+    }
+
 }

--- a/src/main/java/ru/rt/restream/reindexer/annotations/Hnsw.java
+++ b/src/main/java/ru/rt/restream/reindexer/annotations/Hnsw.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Restream
+ * Copyright 2020-present Restream
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/ru/rt/restream/reindexer/annotations/Hnsw.java
+++ b/src/main/java/ru/rt/restream/reindexer/annotations/Hnsw.java
@@ -100,17 +100,17 @@ public @interface Hnsw {
         String quantizationType() default "";
 
         /**
-         * Quantile for scalar quantization.
+         * Quantile for scalar quantization. Must be in range [0.95, 1.0]
          */
         float quantile() default -1.0f;
 
         /**
-         * Sample size for estimating quantile(s).
+         * Sample size for estimating quantile(s). Must be in range [1, UINT64_MAX]
          */
         int sampleSize() default 20_000;
 
         /**
-         * Minimal number of points in the index required to enable quantization.
+         * Minimal number of points in the index required to enable quantization. Must be in range [1, UINT64_MAX]
          */
         int quantizationThreshold() default 100_000;
     }

--- a/src/main/java/ru/rt/restream/reindexer/annotations/Ivf.java
+++ b/src/main/java/ru/rt/restream/reindexer/annotations/Ivf.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Restream
+ * Copyright 2020-present Restream
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/ru/rt/restream/reindexer/annotations/Json.java
+++ b/src/main/java/ru/rt/restream/reindexer/annotations/Json.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Restream
+ * Copyright 2020-present Restream
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/ru/rt/restream/reindexer/annotations/Metric.java
+++ b/src/main/java/ru/rt/restream/reindexer/annotations/Metric.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Restream
+ * Copyright 2020-present Restream
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/ru/rt/restream/reindexer/annotations/Reindex.java
+++ b/src/main/java/ru/rt/restream/reindexer/annotations/Reindex.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Restream
+ * Copyright 2020-present Restream
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/ru/rt/restream/reindexer/annotations/ReindexAnnotationScanner.java
+++ b/src/main/java/ru/rt/restream/reindexer/annotations/ReindexAnnotationScanner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Restream
+ * Copyright 2020-present Restream
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/ru/rt/restream/reindexer/annotations/Serial.java
+++ b/src/main/java/ru/rt/restream/reindexer/annotations/Serial.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Restream
+ * Copyright 2020-present Restream
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/ru/rt/restream/reindexer/annotations/Transient.java
+++ b/src/main/java/ru/rt/restream/reindexer/annotations/Transient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Restream
+ * Copyright 2020-present Restream
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/ru/rt/restream/reindexer/annotations/VecBf.java
+++ b/src/main/java/ru/rt/restream/reindexer/annotations/VecBf.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Restream
+ * Copyright 2020-present Restream
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/ru/rt/restream/reindexer/annotations/package-info.java
+++ b/src/main/java/ru/rt/restream/reindexer/annotations/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Restream
+ * Copyright 2020-present Restream
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/ru/rt/restream/reindexer/binding/Binding.java
+++ b/src/main/java/ru/rt/restream/reindexer/binding/Binding.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Restream
+ * Copyright 2020-present Restream
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/ru/rt/restream/reindexer/binding/Consts.java
+++ b/src/main/java/ru/rt/restream/reindexer/binding/Consts.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Restream
+ * Copyright 2020-present Restream
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/ru/rt/restream/reindexer/binding/QueryResult.java
+++ b/src/main/java/ru/rt/restream/reindexer/binding/QueryResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Restream
+ * Copyright 2020-present Restream
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/ru/rt/restream/reindexer/binding/QueryResultReader.java
+++ b/src/main/java/ru/rt/restream/reindexer/binding/QueryResultReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Restream
+ * Copyright 2020-present Restream
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/ru/rt/restream/reindexer/binding/RequestContext.java
+++ b/src/main/java/ru/rt/restream/reindexer/binding/RequestContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Restream
+ * Copyright 2020-present Restream
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/ru/rt/restream/reindexer/binding/TransactionContext.java
+++ b/src/main/java/ru/rt/restream/reindexer/binding/TransactionContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Restream
+ * Copyright 2020-present Restream
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/ru/rt/restream/reindexer/binding/builtin/Builtin.java
+++ b/src/main/java/ru/rt/restream/reindexer/binding/builtin/Builtin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Restream
+ * Copyright 2020-present Restream
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/ru/rt/restream/reindexer/binding/builtin/BuiltinAdapter.java
+++ b/src/main/java/ru/rt/restream/reindexer/binding/builtin/BuiltinAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Restream
+ * Copyright 2020-present Restream
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/ru/rt/restream/reindexer/binding/builtin/BuiltinRequestContext.java
+++ b/src/main/java/ru/rt/restream/reindexer/binding/builtin/BuiltinRequestContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Restream
+ * Copyright 2020-present Restream
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/ru/rt/restream/reindexer/binding/builtin/BuiltinTransactionContext.java
+++ b/src/main/java/ru/rt/restream/reindexer/binding/builtin/BuiltinTransactionContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Restream
+ * Copyright 2020-present Restream
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/ru/rt/restream/reindexer/binding/builtin/package-info.java
+++ b/src/main/java/ru/rt/restream/reindexer/binding/builtin/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Restream
+ * Copyright 2020-present Restream
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/ru/rt/restream/reindexer/binding/builtin/server/BuiltinServer.java
+++ b/src/main/java/ru/rt/restream/reindexer/binding/builtin/server/BuiltinServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Restream
+ * Copyright 2020-present Restream
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/ru/rt/restream/reindexer/binding/builtin/server/package-info.java
+++ b/src/main/java/ru/rt/restream/reindexer/binding/builtin/server/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Restream
+ * Copyright 2020-present Restream
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/ru/rt/restream/reindexer/binding/cproto/ByteBuffer.java
+++ b/src/main/java/ru/rt/restream/reindexer/binding/cproto/ByteBuffer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Restream
+ * Copyright 2020-present Restream
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/ru/rt/restream/reindexer/binding/cproto/Connection.java
+++ b/src/main/java/ru/rt/restream/reindexer/binding/cproto/Connection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Restream
+ * Copyright 2020-present Restream
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/ru/rt/restream/reindexer/binding/cproto/ConnectionPool.java
+++ b/src/main/java/ru/rt/restream/reindexer/binding/cproto/ConnectionPool.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Restream
+ * Copyright 2020-present Restream
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/ru/rt/restream/reindexer/binding/cproto/Cproto.java
+++ b/src/main/java/ru/rt/restream/reindexer/binding/cproto/Cproto.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Restream
+ * Copyright 2020-present Restream
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/ru/rt/restream/reindexer/binding/cproto/CprotoRequestContext.java
+++ b/src/main/java/ru/rt/restream/reindexer/binding/cproto/CprotoRequestContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Restream
+ * Copyright 2020-present Restream
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/ru/rt/restream/reindexer/binding/cproto/CprotoTransactionContext.java
+++ b/src/main/java/ru/rt/restream/reindexer/binding/cproto/CprotoTransactionContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Restream
+ * Copyright 2020-present Restream
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/ru/rt/restream/reindexer/binding/cproto/DataSource.java
+++ b/src/main/java/ru/rt/restream/reindexer/binding/cproto/DataSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Restream
+ * Copyright 2020-present Restream
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/ru/rt/restream/reindexer/binding/cproto/DataSourceConfiguration.java
+++ b/src/main/java/ru/rt/restream/reindexer/binding/cproto/DataSourceConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Restream
+ * Copyright 2020-present Restream
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/ru/rt/restream/reindexer/binding/cproto/DataSourceFactory.java
+++ b/src/main/java/ru/rt/restream/reindexer/binding/cproto/DataSourceFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Restream
+ * Copyright 2020-present Restream
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/ru/rt/restream/reindexer/binding/cproto/DataSourceFactoryStrategy.java
+++ b/src/main/java/ru/rt/restream/reindexer/binding/cproto/DataSourceFactoryStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Restream
+ * Copyright 2020-present Restream
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/ru/rt/restream/reindexer/binding/cproto/ItemReader.java
+++ b/src/main/java/ru/rt/restream/reindexer/binding/cproto/ItemReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Restream
+ * Copyright 2020-present Restream
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/ru/rt/restream/reindexer/binding/cproto/ItemSerializer.java
+++ b/src/main/java/ru/rt/restream/reindexer/binding/cproto/ItemSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Restream
+ * Copyright 2020-present Restream
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/ru/rt/restream/reindexer/binding/cproto/ItemWriter.java
+++ b/src/main/java/ru/rt/restream/reindexer/binding/cproto/ItemWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Restream
+ * Copyright 2020-present Restream
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/ru/rt/restream/reindexer/binding/cproto/PhysicalConnection.java
+++ b/src/main/java/ru/rt/restream/reindexer/binding/cproto/PhysicalConnection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Restream
+ * Copyright 2020-present Restream
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/ru/rt/restream/reindexer/binding/cproto/PhysicalDataSource.java
+++ b/src/main/java/ru/rt/restream/reindexer/binding/cproto/PhysicalDataSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Restream
+ * Copyright 2020-present Restream
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/ru/rt/restream/reindexer/binding/cproto/cjson/CJsonItemWriter.java
+++ b/src/main/java/ru/rt/restream/reindexer/binding/cproto/cjson/CJsonItemWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Restream
+ * Copyright 2020-present Restream
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/ru/rt/restream/reindexer/binding/cproto/cjson/CjsonArray.java
+++ b/src/main/java/ru/rt/restream/reindexer/binding/cproto/cjson/CjsonArray.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Restream
+ * Copyright 2020-present Restream
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/ru/rt/restream/reindexer/binding/cproto/cjson/CjsonElement.java
+++ b/src/main/java/ru/rt/restream/reindexer/binding/cproto/cjson/CjsonElement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Restream
+ * Copyright 2020-present Restream
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/ru/rt/restream/reindexer/binding/cproto/cjson/CjsonItemReader.java
+++ b/src/main/java/ru/rt/restream/reindexer/binding/cproto/cjson/CjsonItemReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Restream
+ * Copyright 2020-present Restream
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/ru/rt/restream/reindexer/binding/cproto/cjson/CjsonItemSerializer.java
+++ b/src/main/java/ru/rt/restream/reindexer/binding/cproto/cjson/CjsonItemSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Restream
+ * Copyright 2020-present Restream
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/ru/rt/restream/reindexer/binding/cproto/cjson/CjsonNull.java
+++ b/src/main/java/ru/rt/restream/reindexer/binding/cproto/cjson/CjsonNull.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Restream
+ * Copyright 2020-present Restream
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/ru/rt/restream/reindexer/binding/cproto/cjson/CjsonObject.java
+++ b/src/main/java/ru/rt/restream/reindexer/binding/cproto/cjson/CjsonObject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Restream
+ * Copyright 2020-present Restream
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/ru/rt/restream/reindexer/binding/cproto/cjson/CjsonPrimitive.java
+++ b/src/main/java/ru/rt/restream/reindexer/binding/cproto/cjson/CjsonPrimitive.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Restream
+ * Copyright 2020-present Restream
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/ru/rt/restream/reindexer/binding/cproto/cjson/CtagMatcher.java
+++ b/src/main/java/ru/rt/restream/reindexer/binding/cproto/cjson/CtagMatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Restream
+ * Copyright 2020-present Restream
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/ru/rt/restream/reindexer/binding/cproto/cjson/PayloadField.java
+++ b/src/main/java/ru/rt/restream/reindexer/binding/cproto/cjson/PayloadField.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Restream
+ * Copyright 2020-present Restream
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/ru/rt/restream/reindexer/binding/cproto/cjson/PayloadType.java
+++ b/src/main/java/ru/rt/restream/reindexer/binding/cproto/cjson/PayloadType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Restream
+ * Copyright 2020-present Restream
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/ru/rt/restream/reindexer/binding/cproto/cjson/encdec/CarrayTag.java
+++ b/src/main/java/ru/rt/restream/reindexer/binding/cproto/cjson/encdec/CarrayTag.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Restream
+ * Copyright 2020-present Restream
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/ru/rt/restream/reindexer/binding/cproto/cjson/encdec/CjsonDecoder.java
+++ b/src/main/java/ru/rt/restream/reindexer/binding/cproto/cjson/encdec/CjsonDecoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Restream
+ * Copyright 2020-present Restream
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/ru/rt/restream/reindexer/binding/cproto/cjson/encdec/CjsonEncoder.java
+++ b/src/main/java/ru/rt/restream/reindexer/binding/cproto/cjson/encdec/CjsonEncoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Restream
+ * Copyright 2020-present Restream
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/ru/rt/restream/reindexer/binding/cproto/cjson/encdec/Ctag.java
+++ b/src/main/java/ru/rt/restream/reindexer/binding/cproto/cjson/encdec/Ctag.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Restream
+ * Copyright 2020-present Restream
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/ru/rt/restream/reindexer/binding/cproto/cjson/encdec/package-info.java
+++ b/src/main/java/ru/rt/restream/reindexer/binding/cproto/cjson/encdec/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Restream
+ * Copyright 2020-present Restream
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/ru/rt/restream/reindexer/binding/cproto/cjson/package-info.java
+++ b/src/main/java/ru/rt/restream/reindexer/binding/cproto/cjson/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Restream
+ * Copyright 2020-present Restream
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/ru/rt/restream/reindexer/binding/cproto/json/JsonItemSerializer.java
+++ b/src/main/java/ru/rt/restream/reindexer/binding/cproto/json/JsonItemSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Restream
+ * Copyright 2020-present Restream
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/ru/rt/restream/reindexer/binding/cproto/json/package-info.java
+++ b/src/main/java/ru/rt/restream/reindexer/binding/cproto/json/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Restream
+ * Copyright 2020-present Restream
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/ru/rt/restream/reindexer/binding/cproto/package-info.java
+++ b/src/main/java/ru/rt/restream/reindexer/binding/cproto/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Restream
+ * Copyright 2020-present Restream
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/ru/rt/restream/reindexer/binding/cproto/util/ConnectionUtils.java
+++ b/src/main/java/ru/rt/restream/reindexer/binding/cproto/util/ConnectionUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Restream
+ * Copyright 2020-present Restream
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/ru/rt/restream/reindexer/binding/cproto/util/package-info.java
+++ b/src/main/java/ru/rt/restream/reindexer/binding/cproto/util/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Restream
+ * Copyright 2020-present Restream
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/ru/rt/restream/reindexer/binding/definition/IndexConfig.java
+++ b/src/main/java/ru/rt/restream/reindexer/binding/definition/IndexConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Restream
+ * Copyright 2020-present Restream
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/ru/rt/restream/reindexer/binding/definition/IndexDefinition.java
+++ b/src/main/java/ru/rt/restream/reindexer/binding/definition/IndexDefinition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Restream
+ * Copyright 2020-present Restream
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/ru/rt/restream/reindexer/binding/definition/NamespaceDefinition.java
+++ b/src/main/java/ru/rt/restream/reindexer/binding/definition/NamespaceDefinition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Restream
+ * Copyright 2020-present Restream
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/ru/rt/restream/reindexer/binding/definition/Nodes.java
+++ b/src/main/java/ru/rt/restream/reindexer/binding/definition/Nodes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Restream
+ * Copyright 2020-present Restream
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/ru/rt/restream/reindexer/binding/definition/package-info.java
+++ b/src/main/java/ru/rt/restream/reindexer/binding/definition/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Restream
+ * Copyright 2020-present Restream
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/ru/rt/restream/reindexer/binding/package-info.java
+++ b/src/main/java/ru/rt/restream/reindexer/binding/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Restream
+ * Copyright 2020-present Restream
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/ru/rt/restream/reindexer/convert/FieldConverter.java
+++ b/src/main/java/ru/rt/restream/reindexer/convert/FieldConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Restream
+ * Copyright 2020-present Restream
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/ru/rt/restream/reindexer/convert/FieldConverterRegistry.java
+++ b/src/main/java/ru/rt/restream/reindexer/convert/FieldConverterRegistry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Restream
+ * Copyright 2020-present Restream
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/ru/rt/restream/reindexer/convert/FieldConverterRegistryFactory.java
+++ b/src/main/java/ru/rt/restream/reindexer/convert/FieldConverterRegistryFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Restream
+ * Copyright 2020-present Restream
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/ru/rt/restream/reindexer/convert/package-info.java
+++ b/src/main/java/ru/rt/restream/reindexer/convert/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Restream
+ * Copyright 2020-present Restream
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/ru/rt/restream/reindexer/convert/util/ConversionUtils.java
+++ b/src/main/java/ru/rt/restream/reindexer/convert/util/ConversionUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Restream
+ * Copyright 2020-present Restream
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/ru/rt/restream/reindexer/convert/util/ResolvableType.java
+++ b/src/main/java/ru/rt/restream/reindexer/convert/util/ResolvableType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Restream
+ * Copyright 2020-present Restream
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/ru/rt/restream/reindexer/exceptions/IndexConflictException.java
+++ b/src/main/java/ru/rt/restream/reindexer/exceptions/IndexConflictException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Restream
+ * Copyright 2020-present Restream
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/ru/rt/restream/reindexer/exceptions/InvalidProtocolException.java
+++ b/src/main/java/ru/rt/restream/reindexer/exceptions/InvalidProtocolException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Restream
+ * Copyright 2020-present Restream
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/ru/rt/restream/reindexer/exceptions/NetworkException.java
+++ b/src/main/java/ru/rt/restream/reindexer/exceptions/NetworkException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Restream
+ * Copyright 2020-present Restream
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/ru/rt/restream/reindexer/exceptions/ReindexerException.java
+++ b/src/main/java/ru/rt/restream/reindexer/exceptions/ReindexerException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Restream
+ * Copyright 2020-present Restream
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/ru/rt/restream/reindexer/exceptions/ReindexerExceptionFactory.java
+++ b/src/main/java/ru/rt/restream/reindexer/exceptions/ReindexerExceptionFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Restream
+ * Copyright 2020-present Restream
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/ru/rt/restream/reindexer/exceptions/StateInvalidatedException.java
+++ b/src/main/java/ru/rt/restream/reindexer/exceptions/StateInvalidatedException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Restream
+ * Copyright 2020-present Restream
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/ru/rt/restream/reindexer/exceptions/UnimplementedException.java
+++ b/src/main/java/ru/rt/restream/reindexer/exceptions/UnimplementedException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Restream
+ * Copyright 2020-present Restream
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/ru/rt/restream/reindexer/exceptions/package-info.java
+++ b/src/main/java/ru/rt/restream/reindexer/exceptions/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Restream
+ * Copyright 2020-present Restream
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/ru/rt/restream/reindexer/expression/Expression.java
+++ b/src/main/java/ru/rt/restream/reindexer/expression/Expression.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Restream
+ * Copyright 2020-present Restream
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/ru/rt/restream/reindexer/expression/FieldExpression.java
+++ b/src/main/java/ru/rt/restream/reindexer/expression/FieldExpression.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Restream
+ * Copyright 2020-present Restream
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/ru/rt/restream/reindexer/expression/FlatArrayLengthFunction.java
+++ b/src/main/java/ru/rt/restream/reindexer/expression/FlatArrayLengthFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Restream
+ * Copyright 2020-present Restream
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/ru/rt/restream/reindexer/expression/FunctionExpression.java
+++ b/src/main/java/ru/rt/restream/reindexer/expression/FunctionExpression.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Restream
+ * Copyright 2020-present Restream
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/ru/rt/restream/reindexer/expression/LiteralExpression.java
+++ b/src/main/java/ru/rt/restream/reindexer/expression/LiteralExpression.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Restream
+ * Copyright 2020-present Restream
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/ru/rt/restream/reindexer/expression/NowFunction.java
+++ b/src/main/java/ru/rt/restream/reindexer/expression/NowFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Restream
+ * Copyright 2020-present Restream
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/ru/rt/restream/reindexer/expression/SetExpression.java
+++ b/src/main/java/ru/rt/restream/reindexer/expression/SetExpression.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Restream
+ * Copyright 2020-present Restream
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/ru/rt/restream/reindexer/expression/StringExpression.java
+++ b/src/main/java/ru/rt/restream/reindexer/expression/StringExpression.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Restream
+ * Copyright 2020-present Restream
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/ru/rt/restream/reindexer/expression/SubQueryExpression.java
+++ b/src/main/java/ru/rt/restream/reindexer/expression/SubQueryExpression.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Restream
+ * Copyright 2020-present Restream
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/ru/rt/restream/reindexer/expression/WhereExpression.java
+++ b/src/main/java/ru/rt/restream/reindexer/expression/WhereExpression.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Restream
+ * Copyright 2020-present Restream
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/ru/rt/restream/reindexer/expression/package-info.java
+++ b/src/main/java/ru/rt/restream/reindexer/expression/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Restream
+ * Copyright 2020-present Restream
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/ru/rt/restream/reindexer/fulltext/FullTextConfig.java
+++ b/src/main/java/ru/rt/restream/reindexer/fulltext/FullTextConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Restream
+ * Copyright 2020-present Restream
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/ru/rt/restream/reindexer/fulltext/Synonym.java
+++ b/src/main/java/ru/rt/restream/reindexer/fulltext/Synonym.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Restream
+ * Copyright 2020-present Restream
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/ru/rt/restream/reindexer/package-info.java
+++ b/src/main/java/ru/rt/restream/reindexer/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Restream
+ * Copyright 2020-present Restream
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/ru/rt/restream/reindexer/util/BeanPropertyUtils.java
+++ b/src/main/java/ru/rt/restream/reindexer/util/BeanPropertyUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Restream
+ * Copyright 2020-present Restream
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/ru/rt/restream/reindexer/util/CollectionUtils.java
+++ b/src/main/java/ru/rt/restream/reindexer/util/CollectionUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Restream
+ * Copyright 2020-present Restream
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/ru/rt/restream/reindexer/util/JsonSerializer.java
+++ b/src/main/java/ru/rt/restream/reindexer/util/JsonSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Restream
+ * Copyright 2020-present Restream
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/ru/rt/restream/reindexer/util/NativeUtils.java
+++ b/src/main/java/ru/rt/restream/reindexer/util/NativeUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Restream
+ * Copyright 2020-present Restream
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/ru/rt/restream/reindexer/util/Pair.java
+++ b/src/main/java/ru/rt/restream/reindexer/util/Pair.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Restream
+ * Copyright 2020-present Restream
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/ru/rt/restream/reindexer/util/package-info.java
+++ b/src/main/java/ru/rt/restream/reindexer/util/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Restream
+ * Copyright 2020-present Restream
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/ru/rt/restream/reindexer/vector/HnswConfig.java
+++ b/src/main/java/ru/rt/restream/reindexer/vector/HnswConfig.java
@@ -63,4 +63,47 @@ public class HnswConfig implements IndexConfig {
      * Enable multithreading insert mode.
      */
     private int multithreading;
+
+    /**
+     * Optional quantization configuration for HNSW index.
+     *
+     * <p>
+     * When this value is {@code null} the {@code quantization_config} block is not
+     * serialized.
+     */
+    private QuantizationConfig quantizationConfig;
+
+    @Setter
+    @Getter
+    @EqualsAndHashCode
+    @NoArgsConstructor(access = AccessLevel.PACKAGE)
+    public static class QuantizationConfig {
+        /**
+         * Quantization type.
+         *
+         * <p>
+         * Currently supported: {@code scalar_quantization_8_bit}.
+         */
+        private String quantizationType;
+
+        /**
+         * Quantile for scalar quantization.
+         *
+         * <p>
+         * If this field is {@code null}, quantile is expected to be computed
+         * automatically
+         * by Reindexer.
+         */
+        private Float quantile;
+
+        /**
+         * Sample size for estimating quantile(s).
+         */
+        private int sampleSize;
+
+        /**
+         * Minimal number of samples/points required to enable quantization.
+         */
+        private int quantizationThreshold;
+    }
 }

--- a/src/main/java/ru/rt/restream/reindexer/vector/HnswConfig.java
+++ b/src/main/java/ru/rt/restream/reindexer/vector/HnswConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Restream
+ * Copyright 2020-present Restream
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/ru/rt/restream/reindexer/vector/HnswConfigs.java
+++ b/src/main/java/ru/rt/restream/reindexer/vector/HnswConfigs.java
@@ -30,6 +30,11 @@ public class HnswConfigs {
             new IllegalArgumentException("HNSW index should have 'm' parameter in range [2, 128]");
     public static final IllegalArgumentException EF_CONSTRUCTION_NOT_IN_RANGE_EX =
             new IllegalArgumentException("HNSW index should have 'efConstruction' parameter in range [4, 1024]");
+    public static final IllegalArgumentException QUANTIZATION_TYPE_NOT_SUPPORTED_EX =
+            new IllegalArgumentException("Only 'scalar_quantization_8_bit' is supported for HNSW quantization_config.");
+    public static final IllegalArgumentException QUANTILE_OUT_OF_RANGE_EX =
+            new IllegalArgumentException("Quantile for scalar quantization must be in range [0.95, 1.0].");
+    private static final float QUANTILE_UNSET = -1.0f;
 
     public static HnswConfig of(Hnsw annotation) {
         if (annotation.metric() == null) {
@@ -52,6 +57,28 @@ public class HnswConfigs {
         config.setM(annotation.m());
         config.setEfConstruction(annotation.efConstruction());
         config.setMultithreading(annotation.multithreading() ? 1 : 0);
+
+        String quantizationType = annotation.quantizationConfig().quantizationType();
+        float quantile = annotation.quantizationConfig().quantile();
+        int sampleSize = annotation.quantizationConfig().sampleSize();
+        int quantizationThreshold = annotation.quantizationConfig().quantizationThreshold();
+
+        if (quantizationType != null && !quantizationType.isEmpty()) {
+            if (!"scalar_quantization_8_bit".equals(quantizationType)) {
+                throw QUANTIZATION_TYPE_NOT_SUPPORTED_EX;
+            }
+            HnswConfig.QuantizationConfig quantizationConfig = new HnswConfig.QuantizationConfig();
+            quantizationConfig.setQuantizationType(quantizationType);
+            if (quantile != QUANTILE_UNSET) {
+                if (quantile < 0.95f || quantile > 1.0f) {
+                    throw QUANTILE_OUT_OF_RANGE_EX;
+                }
+                quantizationConfig.setQuantile(quantile);
+            }
+            quantizationConfig.setSampleSize(sampleSize);
+            quantizationConfig.setQuantizationThreshold(quantizationThreshold);
+            config.setQuantizationConfig(quantizationConfig);
+        }
         return config;
     }
 

--- a/src/main/java/ru/rt/restream/reindexer/vector/HnswConfigs.java
+++ b/src/main/java/ru/rt/restream/reindexer/vector/HnswConfigs.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Restream
+ * Copyright 2020-present Restream
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/ru/rt/restream/reindexer/vector/IvfConfig.java
+++ b/src/main/java/ru/rt/restream/reindexer/vector/IvfConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Restream
+ * Copyright 2020-present Restream
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/ru/rt/restream/reindexer/vector/IvfConfigs.java
+++ b/src/main/java/ru/rt/restream/reindexer/vector/IvfConfigs.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Restream
+ * Copyright 2020-present Restream
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/ru/rt/restream/reindexer/vector/VecBfConfig.java
+++ b/src/main/java/ru/rt/restream/reindexer/vector/VecBfConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Restream
+ * Copyright 2020-present Restream
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/ru/rt/restream/reindexer/vector/VecBfConfigs.java
+++ b/src/main/java/ru/rt/restream/reindexer/vector/VecBfConfigs.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Restream
+ * Copyright 2020-present Restream
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/ru/rt/restream/reindexer/vector/params/BaseKnnSearchParam.java
+++ b/src/main/java/ru/rt/restream/reindexer/vector/params/BaseKnnSearchParam.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Restream
+ * Copyright 2020-present Restream
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/ru/rt/restream/reindexer/vector/params/IndexBfSearchParam.java
+++ b/src/main/java/ru/rt/restream/reindexer/vector/params/IndexBfSearchParam.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Restream
+ * Copyright 2020-present Restream
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/ru/rt/restream/reindexer/vector/params/IndexHnswSearchParam.java
+++ b/src/main/java/ru/rt/restream/reindexer/vector/params/IndexHnswSearchParam.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Restream
+ * Copyright 2020-present Restream
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/ru/rt/restream/reindexer/vector/params/IndexIvfSearchParam.java
+++ b/src/main/java/ru/rt/restream/reindexer/vector/params/IndexIvfSearchParam.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Restream
+ * Copyright 2020-present Restream
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/ru/rt/restream/reindexer/vector/params/KnnParams.java
+++ b/src/main/java/ru/rt/restream/reindexer/vector/params/KnnParams.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Restream
+ * Copyright 2020-present Restream
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/ru/rt/restream/reindexer/vector/params/KnnSearchParam.java
+++ b/src/main/java/ru/rt/restream/reindexer/vector/params/KnnSearchParam.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Restream
+ * Copyright 2020-present Restream
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/ru/rt/restream/category/BuiltinTest.java
+++ b/src/test/java/ru/rt/restream/category/BuiltinTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Restream
+ * Copyright 2020-present Restream
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/ru/rt/restream/category/CprotoTest.java
+++ b/src/test/java/ru/rt/restream/category/CprotoTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Restream
+ * Copyright 2020-present Restream
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/ru/rt/restream/reindexer/TimeUnitTest.java
+++ b/src/test/java/ru/rt/restream/reindexer/TimeUnitTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Restream
+ * Copyright 2020-present Restream
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/ru/rt/restream/reindexer/annotations/FullTextTest.java
+++ b/src/test/java/ru/rt/restream/reindexer/annotations/FullTextTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Restream
+ * Copyright 2020-present Restream
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/ru/rt/restream/reindexer/annotations/JsonTest.java
+++ b/src/test/java/ru/rt/restream/reindexer/annotations/JsonTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Restream
+ * Copyright 2020-present Restream
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/ru/rt/restream/reindexer/annotations/ReindexTest.java
+++ b/src/test/java/ru/rt/restream/reindexer/annotations/ReindexTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Restream
+ * Copyright 2020-present Restream
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/ru/rt/restream/reindexer/connector/AggregationTest.java
+++ b/src/test/java/ru/rt/restream/reindexer/connector/AggregationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Restream
+ * Copyright 2020-present Restream
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/ru/rt/restream/reindexer/connector/BuiltinAggregationTest.java
+++ b/src/test/java/ru/rt/restream/reindexer/connector/BuiltinAggregationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Restream
+ * Copyright 2020-present Restream
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/ru/rt/restream/reindexer/connector/BuiltinFloatVectorBfTest.java
+++ b/src/test/java/ru/rt/restream/reindexer/connector/BuiltinFloatVectorBfTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Restream
+ * Copyright 2020-present Restream
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/ru/rt/restream/reindexer/connector/BuiltinFloatVectorHnswTest.java
+++ b/src/test/java/ru/rt/restream/reindexer/connector/BuiltinFloatVectorHnswTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Restream
+ * Copyright 2020-present Restream
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/ru/rt/restream/reindexer/connector/BuiltinFloatVectorIvfTest.java
+++ b/src/test/java/ru/rt/restream/reindexer/connector/BuiltinFloatVectorIvfTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Restream
+ * Copyright 2020-present Restream
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/ru/rt/restream/reindexer/connector/BuiltinFullTextRankTest.java
+++ b/src/test/java/ru/rt/restream/reindexer/connector/BuiltinFullTextRankTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Restream
+ * Copyright 2020-present Restream
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/ru/rt/restream/reindexer/connector/BuiltinHnswQuantizationConfigUpdateTest.java
+++ b/src/test/java/ru/rt/restream/reindexer/connector/BuiltinHnswQuantizationConfigUpdateTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Restream
+ * Copyright 2020-present Restream
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/ru/rt/restream/reindexer/connector/BuiltinHnswQuantizationConfigUpdateTest.java
+++ b/src/test/java/ru/rt/restream/reindexer/connector/BuiltinHnswQuantizationConfigUpdateTest.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2020 Restream
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ru.rt.restream.reindexer.connector;
+
+import ru.rt.restream.category.BuiltinTest;
+
+@BuiltinTest
+public class BuiltinHnswQuantizationConfigUpdateTest extends HnswQuantizationConfigUpdateTest {
+}
+

--- a/src/test/java/ru/rt/restream/reindexer/connector/BuiltinIndexOperationTest.java
+++ b/src/test/java/ru/rt/restream/reindexer/connector/BuiltinIndexOperationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Restream
+ * Copyright 2020-present Restream
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/ru/rt/restream/reindexer/connector/BuiltinJoinTest.java
+++ b/src/test/java/ru/rt/restream/reindexer/connector/BuiltinJoinTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Restream
+ * Copyright 2020-present Restream
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/ru/rt/restream/reindexer/connector/BuiltinMergeTest.java
+++ b/src/test/java/ru/rt/restream/reindexer/connector/BuiltinMergeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Restream
+ * Copyright 2020-present Restream
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/ru/rt/restream/reindexer/connector/BuiltinReindexerTest.java
+++ b/src/test/java/ru/rt/restream/reindexer/connector/BuiltinReindexerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Restream
+ * Copyright 2020-present Restream
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/ru/rt/restream/reindexer/connector/BuiltinSubQueryTest.java
+++ b/src/test/java/ru/rt/restream/reindexer/connector/BuiltinSubQueryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Restream
+ * Copyright 2020-present Restream
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/ru/rt/restream/reindexer/connector/BuiltinVectorRankTest.java
+++ b/src/test/java/ru/rt/restream/reindexer/connector/BuiltinVectorRankTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Restream
+ * Copyright 2020-present Restream
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/ru/rt/restream/reindexer/connector/CprotoAggregationTest.java
+++ b/src/test/java/ru/rt/restream/reindexer/connector/CprotoAggregationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Restream
+ * Copyright 2020-present Restream
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/ru/rt/restream/reindexer/connector/CprotoFloatVectorBfTest.java
+++ b/src/test/java/ru/rt/restream/reindexer/connector/CprotoFloatVectorBfTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Restream
+ * Copyright 2020-present Restream
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/ru/rt/restream/reindexer/connector/CprotoFloatVectorHnswTest.java
+++ b/src/test/java/ru/rt/restream/reindexer/connector/CprotoFloatVectorHnswTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Restream
+ * Copyright 2020-present Restream
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/ru/rt/restream/reindexer/connector/CprotoFloatVectorIvfTest.java
+++ b/src/test/java/ru/rt/restream/reindexer/connector/CprotoFloatVectorIvfTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Restream
+ * Copyright 2020-present Restream
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/ru/rt/restream/reindexer/connector/CprotoFullTextRankTest.java
+++ b/src/test/java/ru/rt/restream/reindexer/connector/CprotoFullTextRankTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Restream
+ * Copyright 2020-present Restream
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/ru/rt/restream/reindexer/connector/CprotoHnswQuantizationConfigUpdateTest.java
+++ b/src/test/java/ru/rt/restream/reindexer/connector/CprotoHnswQuantizationConfigUpdateTest.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2020 Restream
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ru.rt.restream.reindexer.connector;
+
+import ru.rt.restream.category.CprotoTest;
+
+@CprotoTest
+public class CprotoHnswQuantizationConfigUpdateTest extends HnswQuantizationConfigUpdateTest {
+}
+

--- a/src/test/java/ru/rt/restream/reindexer/connector/CprotoHnswQuantizationConfigUpdateTest.java
+++ b/src/test/java/ru/rt/restream/reindexer/connector/CprotoHnswQuantizationConfigUpdateTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Restream
+ * Copyright 2020-present Restream
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/ru/rt/restream/reindexer/connector/CprotoIndexOperationTest.java
+++ b/src/test/java/ru/rt/restream/reindexer/connector/CprotoIndexOperationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Restream
+ * Copyright 2020-present Restream
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/ru/rt/restream/reindexer/connector/CprotoJoinTest.java
+++ b/src/test/java/ru/rt/restream/reindexer/connector/CprotoJoinTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Restream
+ * Copyright 2020-present Restream
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/ru/rt/restream/reindexer/connector/CprotoMergeTest.java
+++ b/src/test/java/ru/rt/restream/reindexer/connector/CprotoMergeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Restream
+ * Copyright 2020-present Restream
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/ru/rt/restream/reindexer/connector/CprotoReindexerTest.java
+++ b/src/test/java/ru/rt/restream/reindexer/connector/CprotoReindexerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Restream
+ * Copyright 2020-present Restream
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/ru/rt/restream/reindexer/connector/CprotoSubQueryTest.java
+++ b/src/test/java/ru/rt/restream/reindexer/connector/CprotoSubQueryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Restream
+ * Copyright 2020-present Restream
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/ru/rt/restream/reindexer/connector/CprotoVectorRankTest.java
+++ b/src/test/java/ru/rt/restream/reindexer/connector/CprotoVectorRankTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Restream
+ * Copyright 2020-present Restream
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/ru/rt/restream/reindexer/connector/CprotosReindexerTest.java
+++ b/src/test/java/ru/rt/restream/reindexer/connector/CprotosReindexerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Restream
+ * Copyright 2020-present Restream
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/ru/rt/restream/reindexer/connector/FloatVectorBfTest.java
+++ b/src/test/java/ru/rt/restream/reindexer/connector/FloatVectorBfTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Restream
+ * Copyright 2020-present Restream
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/ru/rt/restream/reindexer/connector/FloatVectorHnswTest.java
+++ b/src/test/java/ru/rt/restream/reindexer/connector/FloatVectorHnswTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Restream
+ * Copyright 2020-present Restream
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/ru/rt/restream/reindexer/connector/FloatVectorIvfTest.java
+++ b/src/test/java/ru/rt/restream/reindexer/connector/FloatVectorIvfTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Restream
+ * Copyright 2020-present Restream
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/ru/rt/restream/reindexer/connector/FullTextRankTest.java
+++ b/src/test/java/ru/rt/restream/reindexer/connector/FullTextRankTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Restream
+ * Copyright 2020-present Restream
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/ru/rt/restream/reindexer/connector/HnswQuantizationConfigUpdateTest.java
+++ b/src/test/java/ru/rt/restream/reindexer/connector/HnswQuantizationConfigUpdateTest.java
@@ -1,0 +1,198 @@
+/*
+ * Copyright 2020 Restream
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ru.rt.restream.reindexer.connector;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.junit.jupiter.api.Test;
+import ru.rt.restream.reindexer.CollateMode;
+import ru.rt.restream.reindexer.FieldType;
+import ru.rt.restream.reindexer.IndexType;
+import ru.rt.restream.reindexer.Namespace;
+import ru.rt.restream.reindexer.NamespaceOptions;
+import ru.rt.restream.reindexer.ReindexerIndex;
+import ru.rt.restream.reindexer.annotations.Hnsw;
+import ru.rt.restream.reindexer.annotations.Json;
+import ru.rt.restream.reindexer.annotations.Metric;
+import ru.rt.restream.reindexer.annotations.Reindex;
+import ru.rt.restream.reindexer.db.DbBaseTest;
+import ru.rt.restream.reindexer.vector.HnswConfig;
+
+import java.lang.reflect.Constructor;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+abstract class HnswQuantizationConfigUpdateTest extends DbBaseTest {
+    private final String namespaceName = "hnsw_quantization_config_update";
+    private final String vectorIndexName = "vector";
+
+    @Test
+    void testChangeQuantizationConfig() {
+        db.openNamespace(namespaceName, NamespaceOptions.defaultOptions(), VectorItem.class);
+
+        NamespaceDescriptionResponse before = getNamespaceDescription(namespaceName);
+        IndexResponse vectorIndexBefore = getIndexByName(before.getIndexes(), vectorIndexName);
+        QuantizationConfigResponse quantBefore = vectorIndexBefore.getConfig().getQuantizationConfig();
+
+        assertThat(quantBefore.getQuantizationType(), is("scalar_quantization_8_bit"));
+        assertThat(quantBefore.getSampleSize(), is(20_000));
+        assertThat(quantBefore.getQuantizationThreshold(), is(100_000));
+        assertThat(quantBefore.getQuantile(), nullValue());
+
+        ReindexerIndex updIndex = createHnswIndexForUpdate(vectorIndexName);
+        HnswConfig hnswConfig = createHnswConfigForUpdate();
+        updIndex.setConfig(hnswConfig);
+        db.updateIndex(namespaceName, updIndex);
+
+        NamespaceDescriptionResponse after = getNamespaceDescription(namespaceName);
+        IndexResponse vectorIndexAfter = getIndexByName(after.getIndexes(), vectorIndexName);
+        QuantizationConfigResponse quantAfter = vectorIndexAfter.getConfig().getQuantizationConfig();
+
+        assertThat(quantAfter.getQuantizationType(), is("scalar_quantization_8_bit"));
+        assertEquals(0.987f, quantAfter.getQuantile(), 1e-6f);
+        assertThat(quantAfter.getSampleSize(), is(12340));
+        assertThat(quantAfter.getQuantizationThreshold(), is(43210));
+    }
+
+    private NamespaceDescriptionResponse getNamespaceDescription(String nsName) {
+        Namespace<NamespaceDescriptionResponse> serviceNamespace = db.openNamespace("#namespaces",
+                NamespaceOptions.defaultOptions(), NamespaceDescriptionResponse.class);
+        String query = String.format("select * from #namespaces where name = '%s'", nsName);
+        Iterator<NamespaceDescriptionResponse> iterator = serviceNamespace.execSql(query);
+        if (!iterator.hasNext()) {
+            throw new AssertionError("Namespace is not found: " + nsName);
+        }
+        return iterator.next();
+    }
+
+    private IndexResponse getIndexByName(List<IndexResponse> indexes, String indexName) {
+        return indexes.stream()
+                .filter(i -> indexName.equals(i.getName()))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("Index is not found: " + indexName));
+    }
+
+    private ReindexerIndex createHnswIndexForUpdate(String indexName) {
+        // index update requires the same structural info (index type + field type +
+        // json path)
+        return ReindexerIndex.builder()
+                .name(indexName)
+                .jsonPaths(Collections.singletonList(indexName))
+                .indexType(IndexType.HNSW)
+                .fieldType(FieldType.FLOAT_VECTOR)
+                .collateMode(CollateMode.NONE)
+                .build();
+    }
+
+    private HnswConfig createHnswConfigForUpdate() {
+        HnswConfig config = newHnswConfig();
+        config.setMetric("cosine");
+        config.setDimension(1024);
+        config.setStartSize(1000);
+        config.setM(20);
+        config.setEfConstruction(150);
+        config.setMultithreading(0);
+
+        HnswConfig.QuantizationConfig quantConfig = newQuantizationConfig();
+        quantConfig.setQuantizationType("scalar_quantization_8_bit");
+        quantConfig.setQuantile(0.987f);
+        quantConfig.setSampleSize(12340);
+        quantConfig.setQuantizationThreshold(43210);
+        config.setQuantizationConfig(quantConfig);
+        return config;
+    }
+
+    private static HnswConfig newHnswConfig() {
+        try {
+            Constructor<HnswConfig> ctor = HnswConfig.class.getDeclaredConstructor();
+            ctor.setAccessible(true);
+            return ctor.newInstance();
+        } catch (ReflectiveOperationException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static HnswConfig.QuantizationConfig newQuantizationConfig() {
+        try {
+            Constructor<HnswConfig.QuantizationConfig> ctor = HnswConfig.QuantizationConfig.class
+                    .getDeclaredConstructor();
+            ctor.setAccessible(true);
+            return ctor.newInstance();
+        } catch (ReflectiveOperationException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Getter
+    @Setter
+    public static class NamespaceDescriptionResponse {
+        private String name;
+        private List<IndexResponse> indexes;
+    }
+
+    @Getter
+    @Setter
+    public static class IndexResponse {
+        private String name;
+
+        @Json("config")
+        private IndexConfigResponse config;
+    }
+
+    @Getter
+    @Setter
+    public static class IndexConfigResponse {
+        @Json("quantization_config")
+        private QuantizationConfigResponse quantizationConfig;
+    }
+
+    @Getter
+    @Setter
+    public static class QuantizationConfigResponse {
+        @Json("quantization_type")
+        private String quantizationType;
+
+        @Json("quantile")
+        private Float quantile;
+
+        @Json("sample_size")
+        private Integer sampleSize;
+
+        @Json("quantization_threshold")
+        private Integer quantizationThreshold;
+    }
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class VectorItem {
+        @Reindex(name = "id", isPrimaryKey = true)
+        private Integer id;
+
+        @Reindex(name = "vector")
+        @Hnsw(metric = Metric.COSINE, dimension = 1024, quantizationConfig = @Hnsw.QuantizationConfig(quantizationType = "scalar_quantization_8_bit"))
+        private float[] vector;
+    }
+}

--- a/src/test/java/ru/rt/restream/reindexer/connector/HnswQuantizationConfigUpdateTest.java
+++ b/src/test/java/ru/rt/restream/reindexer/connector/HnswQuantizationConfigUpdateTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Restream
+ * Copyright 2020-present Restream
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/ru/rt/restream/reindexer/connector/IndexOperationTest.java
+++ b/src/test/java/ru/rt/restream/reindexer/connector/IndexOperationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Restream
+ * Copyright 2020-present Restream
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/ru/rt/restream/reindexer/connector/JoinTest.java
+++ b/src/test/java/ru/rt/restream/reindexer/connector/JoinTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Restream
+ * Copyright 2020-present Restream
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/ru/rt/restream/reindexer/connector/MergeTest.java
+++ b/src/test/java/ru/rt/restream/reindexer/connector/MergeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Restream
+ * Copyright 2020-present Restream
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/ru/rt/restream/reindexer/connector/ReindexerTest.java
+++ b/src/test/java/ru/rt/restream/reindexer/connector/ReindexerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Restream
+ * Copyright 2020-present Restream
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/ru/rt/restream/reindexer/connector/SubQueryTest.java
+++ b/src/test/java/ru/rt/restream/reindexer/connector/SubQueryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Restream
+ * Copyright 2020-present Restream
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/ru/rt/restream/reindexer/connector/VectorRankTest.java
+++ b/src/test/java/ru/rt/restream/reindexer/connector/VectorRankTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Restream
+ * Copyright 2020-present Restream
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/ru/rt/restream/reindexer/convert/FieldConverterRegistryFactoryTest.java
+++ b/src/test/java/ru/rt/restream/reindexer/convert/FieldConverterRegistryFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Restream
+ * Copyright 2020-present Restream
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/ru/rt/restream/reindexer/convert/util/ConversionUtilsTest.java
+++ b/src/test/java/ru/rt/restream/reindexer/convert/util/ConversionUtilsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Restream
+ * Copyright 2020-present Restream
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/ru/rt/restream/reindexer/db/ClearDbReindexer.java
+++ b/src/test/java/ru/rt/restream/reindexer/db/ClearDbReindexer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Restream
+ * Copyright 2020-present Restream
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/ru/rt/restream/reindexer/db/DbBaseTest.java
+++ b/src/test/java/ru/rt/restream/reindexer/db/DbBaseTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Restream
+ * Copyright 2020-present Restream
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/ru/rt/restream/reindexer/db/DbCloseExtension.java
+++ b/src/test/java/ru/rt/restream/reindexer/db/DbCloseExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Restream
+ * Copyright 2020-present Restream
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/ru/rt/restream/reindexer/db/DbLocator.java
+++ b/src/test/java/ru/rt/restream/reindexer/db/DbLocator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Restream
+ * Copyright 2020-present Restream
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/ru/rt/restream/reindexer/fast/ReindexAnnotationScannerHnswIndexTest.java
+++ b/src/test/java/ru/rt/restream/reindexer/fast/ReindexAnnotationScannerHnswIndexTest.java
@@ -62,6 +62,7 @@ public class ReindexAnnotationScannerHnswIndexTest {
         assertThat(vector.getHnswConfig().getM(), is(16));
         assertThat(vector.getHnswConfig().getEfConstruction(), is(200));
         assertThat(vector.getHnswConfig().getMultithreading(), is(0));
+        assertThat(vector.getHnswConfig().getQuantizationConfig(), nullValue());
     }
 
     @Test
@@ -84,6 +85,7 @@ public class ReindexAnnotationScannerHnswIndexTest {
         assertThat(vector.getHnswConfig().getM(), is(5));
         assertThat(vector.getHnswConfig().getEfConstruction(), is(4));
         assertThat(vector.getHnswConfig().getMultithreading(), is(1));
+        assertThat(vector.getHnswConfig().getQuantizationConfig(), nullValue());
     }
 
     @Test
@@ -154,6 +156,21 @@ public class ReindexAnnotationScannerHnswIndexTest {
         private float[] vector;
     }
 
+    @Test
+    public void testConfigScalarQuantization8Bit_isOk() {
+        List<ReindexerIndex> indexes = scanner.parseIndexes(ItemWithScalarQuantization8BitConfig.class);
+        ReindexerIndex vector = getIndexByName(indexes, "hnsw_vector");
+
+        assertThat(vector.getHnswConfig(), notNullValue());
+        assertThat(vector.getHnswConfig().getQuantizationConfig(), notNullValue());
+
+        assertThat(vector.getHnswConfig().getQuantizationConfig().getQuantizationType(),
+                is("scalar_quantization_8_bit"));
+        assertThat(vector.getHnswConfig().getQuantizationConfig().getQuantile(), is(0.987f));
+        assertThat(vector.getHnswConfig().getQuantizationConfig().getSampleSize(), is(3000));
+        assertThat(vector.getHnswConfig().getQuantizationConfig().getQuantizationThreshold(), is(5000));
+    }
+
     static class ItemWithNotHnswIndex {
         @Reindex(name = "id", isPrimaryKey = true)
         private Integer id;
@@ -199,4 +216,12 @@ public class ReindexAnnotationScannerHnswIndexTest {
         private float[] vector;
     }
 
+    static class ItemWithScalarQuantization8BitConfig {
+        @Reindex(name = "id", isPrimaryKey = true)
+        private Integer id;
+
+        @Reindex(name = "hnsw_vector", type = HNSW)
+        @Hnsw(metric = Metric.COSINE, dimension = 1024, quantizationConfig = @Hnsw.QuantizationConfig(quantizationType = "scalar_quantization_8_bit", quantile = 0.987f, sampleSize = 3000, quantizationThreshold = 5000))
+        private float[] vector;
+    }
 }

--- a/src/test/java/ru/rt/restream/reindexer/fast/ReindexAnnotationScannerHnswIndexTest.java
+++ b/src/test/java/ru/rt/restream/reindexer/fast/ReindexAnnotationScannerHnswIndexTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Restream
+ * Copyright 2020-present Restream
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/ru/rt/restream/reindexer/fast/ReindexAnnotationScannerIsAppendableIndexTest.java
+++ b/src/test/java/ru/rt/restream/reindexer/fast/ReindexAnnotationScannerIsAppendableIndexTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Restream
+ * Copyright 2020-present Restream
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/ru/rt/restream/reindexer/fast/ReindexAnnotationScannerIvfIndexTest.java
+++ b/src/test/java/ru/rt/restream/reindexer/fast/ReindexAnnotationScannerIvfIndexTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Restream
+ * Copyright 2020-present Restream
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/ru/rt/restream/reindexer/fast/ReindexAnnotationScannerVecBfIndexTest.java
+++ b/src/test/java/ru/rt/restream/reindexer/fast/ReindexAnnotationScannerVecBfIndexTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Restream
+ * Copyright 2020-present Restream
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/ru/rt/restream/reindexer/util/CollectionUtilsTest.java
+++ b/src/test/java/ru/rt/restream/reindexer/util/CollectionUtilsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Restream
+ * Copyright 2020-present Restream
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/ru/rt/restream/util/ReindexerUtils.java
+++ b/src/test/java/ru/rt/restream/util/ReindexerUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Restream
+ * Copyright 2020-present Restream
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
Добавлена поддержка quantization_config для HNSW-индексов и покрытие нового поведения тестами:

- quantization-конфиг можно обновить через стандартное api  добавления/обновления индексов (удалена аннотация Deprecated из соответствующих методов).
- в аннотацию Hnsw добавлен блок QuantizationConfig
- в HnswConfig добавлена вложенная модель QuantizationConfig
- в HnswConfigs добавлено построение и валидация quantization-конфига из аннотаций
- расширены unit-тесты для сканера аннотаций в ReindexAnnotationScannerHnswIndexTest
- добавлены интеграционные тесты обновления quantization-конфига для builtin и cproto в HnswQuantizationConfigUpdateTest

По умолчанию quantization_config для HNSW не заполняется