### PR TITLE
Fix PT/TM versions calcs for sql queries

### DIFF
--- a/src/main/java/ru/rt/restream/reindexer/Reindexer.java
+++ b/src/main/java/ru/rt/restream/reindexer/Reindexer.java
@@ -251,7 +251,7 @@ public class Reindexer implements AutoCloseable {
         }
         ReindexerNamespace<T> namespace = getNamespace(namespaceName, itemClass);
         PayloadType pt = namespace.getPayloadType();
-        long[] ptVersions = pt == null ? new long[]{0} : new long[]{pt.getVersion()};
+        long[] ptVersions = pt == null ? new long[]{0} : new long[]{pt.getVersion() ^ pt.getStateToken()};
         RequestContext ctx = binding.select(query, false, Integer.MAX_VALUE, ptVersions);
         QueryResult queryResult = ctx.getQueryResult();
         for (PayloadType payloadType : queryResult.getPayloadTypes()) {


### PR DESCRIPTION
Fixed tagsmatcher/payloadtype versions array generation for selectSql. Now implementation corresponds to the query builder's one