### PR TITLE
Support correct aggresults handling for empty namespaces/qrs

### DIFF
--- a/src/main/java/ru/rt/restream/reindexer/AggregationResult.java
+++ b/src/main/java/ru/rt/restream/reindexer/AggregationResult.java
@@ -26,7 +26,7 @@ public class AggregationResult {
 
     private String type;
 
-    private double value;
+    private Double value;
 
     private List<Facet> facets;
 
@@ -114,19 +114,20 @@ public class AggregationResult {
 
     /**
      * Get the current aggregation result value.
+     * {@code null} when there were no items to aggregate over (e.g. empty namespace or query results).
      *
-     * @return the current aggregation result value
+     * @return the current aggregation result value, or {@code null} if absent
      */
-    public double getValue() {
+    public Double getValue() {
         return value;
     }
 
     /**
      * Set the current aggregation result value.
      *
-     * @param value aggregation result value
+     * @param value aggregation result value, or {@code null} if absent
      */
-    public void setValue(double value) {
+    public void setValue(Double value) {
         this.value = value;
     }
 

--- a/src/test/java/ru/rt/restream/reindexer/connector/AggregationTest.java
+++ b/src/test/java/ru/rt/restream/reindexer/connector/AggregationTest.java
@@ -33,6 +33,7 @@ import java.util.Set;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
 
 /**
  * Base Aggregation Test.
@@ -132,6 +133,59 @@ public abstract class AggregationTest extends DbBaseTest {
         ResultIterator<Item> result = query.execute();
         AggregationResult minResult = result.aggResults().get(0);
         assertThat(minResult.getValue(), is(0D));
+    }
+
+    @Test
+    public void testAggregationsOnEmptyNamespace() {
+        Namespace<Item> itemNamespace = db.openNamespace("items", NamespaceOptions.defaultOptions(), Item.class);
+
+        ResultIterator<Item> result = itemNamespace.query()
+                .aggregateSum("price")
+                .aggregateAvg("price")
+                .aggregateMin("price")
+                .aggregateMax("price")
+                .execute();
+
+        List<AggregationResult> aggResults = result.aggResults();
+        assertThat(aggResults.size(), is(4));
+        assertThat(aggResults.get(0).getType(), is("sum"));
+        assertThat(aggResults.get(0).getValue(), is(nullValue()));
+        assertThat(aggResults.get(1).getType(), is("avg"));
+        assertThat(aggResults.get(1).getValue(), is(nullValue()));
+        assertThat(aggResults.get(2).getType(), is("min"));
+        assertThat(aggResults.get(2).getValue(), is(nullValue()));
+        assertThat(aggResults.get(3).getType(), is("max"));
+        assertThat(aggResults.get(3).getValue(), is(nullValue()));
+    }
+
+    @Test
+    public void testAggregationsWithZeroValue() {
+        Namespace<Item> itemNamespace = db.openNamespace("items", NamespaceOptions.defaultOptions(), Item.class);
+
+        for (int i = 0; i < 10; i++) {
+            Item item = new Item();
+            item.setId(i);
+            item.setPrice(0);
+            itemNamespace.insert(item);
+        }
+
+        ResultIterator<Item> result = itemNamespace.query()
+                .aggregateSum("price")
+                .aggregateAvg("price")
+                .aggregateMin("price")
+                .aggregateMax("price")
+                .execute();
+
+        List<AggregationResult> aggResults = result.aggResults();
+        assertThat(aggResults.size(), is(4));
+        assertThat(aggResults.get(0).getType(), is("sum"));
+        assertThat(aggResults.get(0).getValue(), is(0D));
+        assertThat(aggResults.get(1).getType(), is("avg"));
+        assertThat(aggResults.get(1).getValue(), is(0D));
+        assertThat(aggResults.get(2).getType(), is("min"));
+        assertThat(aggResults.get(2).getValue(), is(0D));
+        assertThat(aggResults.get(3).getType(), is("max"));
+        assertThat(aggResults.get(3).getValue(), is(0D));
     }
 
     @Test


### PR DESCRIPTION
In case if query results are empty or there are no items in namespace core library/server will send aggresults without "value"-field in JSON. Previously there were no differences between missing "value" and `"value": 0.0`. `Double`-semantic has better fit with DBMS kernel logic